### PR TITLE
Update headers to support OpenCV 4 and add missing dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(loam_feat_extract src/feature_extract.cpp)
 target_link_libraries(loam_feat_extract ${catkin_LIBRARIES} ${PCL_LIBRARIES})
 
 add_executable(loam_laserMapping src/laserMapping.cpp)
+add_dependencies(loam_laserMapping ${catkin_EXPORTED_TARGETS})
 target_link_libraries(loam_laserMapping ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBS} ${PYTHON_LIBRARIES})
 target_include_directories(loam_laserMapping PRIVATE ${PYTHON_INCLUDE_DIRS})
 # target_compile_definitions(loam_laserMapping PRIVATE ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/include/Exp_mat.h
+++ b/include/Exp_mat.h
@@ -3,7 +3,7 @@
 
 #include <math.h>
 #include <Eigen/Core>
-#include <opencv/cv.h>
+#include <opencv2/core.hpp>
 // #include <common_lib.h>
 
 #define SKEW_SYM_MATRX(v) 0.0,-v[2],v[1],v[2],0.0,-v[0],-v[1],v[0],0.0

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -43,7 +43,7 @@
 #include <Exp_mat.h>
 #include <ros/ros.h>
 #include <Eigen/Core>
-#include <opencv/cv.h>
+#include <opencv2/core.hpp>
 #include <common_lib.h>
 #include "IMU_Processing.hpp"
 #include <nav_msgs/Odometry.h>


### PR DESCRIPTION
Replace opencv/cv.h with opencv2/core.hpp so both OpenCV 3 and OpenCV 4 are supported.
Declare explicit dependencies so msg headers generated from livox_ros_driver could be found.