### PR TITLE
add support for custom PCL build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(fast_lio)
+cmake_policy(SET CMP0074 NEW)
 
 SET(CMAKE_BUILD_TYPE "Debug")
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Clone the repository and catkin_make:
     catkin_make
     source devel/setup.bash
 ```
+*Remarks:*
+- If you want to use a custom build of PCL, add the following line to ~/.bashrc
+```export PCL_ROOT={CUSTOM_PCL_PATH}```
 ## 3. Directly run
 ### 3.1 For indoor environments (support maximum 50hz frame rate)
 Connect to your PC to Livox Avia LiDAR by following  [Livox-ros-driver installation](https://github.com/Livox-SDK/livox_ros_driver), then

--- a/include/so3_math.h
+++ b/include/so3_math.h
@@ -3,7 +3,7 @@
 
 #include <math.h>
 #include <Eigen/Core>
-#include <opencv/cv.h>
+#include <opencv2/core.hpp>
 // #include <common_lib.h>
 
 #define SKEW_SYM_MATRX(v) 0.0,-v[2],v[1],v[2],0.0,-v[0],-v[1],v[0],0.0


### PR DESCRIPTION
By adding a simple cmake_policy() setting, it's able to support custom PCL build configured by environment variable PCL_ROOT.
I'm current trying to accelerate FAST_LIO on Jetson Xavier NX. This minor change is required to use custom PCL build with CUDA.