### PR TITLE
[Fix] Crashes when fed empty pointcloud

### DIFF
--- a/src/IMU_Processing.hpp
+++ b/src/IMU_Processing.hpp
@@ -297,6 +297,7 @@ void ImuProcess::UndistortPcl(const MeasureGroup &meas, esekfom::esekf<state_ikf
   last_lidar_end_time_ = pcl_end_time;
 
   /*** undistort each lidar point (backward propagation) ***/
+  if (pcl_out.points.begin() == pcl_out.points.end()) return;
   auto it_pcl = pcl_out.points.end() - 1;
   for (auto it_kp = IMUpose.end() - 1; it_kp != IMUpose.begin(); it_kp--)
   {

--- a/src/preprocess.cpp
+++ b/src/preprocess.cpp
@@ -267,6 +267,7 @@ void Preprocess::velodyne_handler(const sensor_msgs::PointCloud2::ConstPtr &msg)
     pcl::PointCloud<velodyne_ros::Point> pl_orig;
     pcl::fromROSMsg(*msg, pl_orig);
     int plsize = pl_orig.points.size();
+    if (plsize == 0) return;
     pl_surf.reserve(plsize);
 
     /*** These variables only works when no point timestamps given ***/


### PR DESCRIPTION
Checks if before doing the backward propagation step there are actually points in the pointcloud.

When fed a pointcloud with no points, "[laserMapping-2] process has died ..." is thrown and the program comes to an end.

This is relevant for applications with little FOV, feeding filtered pointclouds and for dealing with unreliable LiDARs.