### PR TITLE
Change gitmodules url for the ikd-tree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "include/ikd-Tree"]
 	path = include/ikd-Tree
-	url = git@github.com:hku-mars/ikd-Tree.git
+	url = https://github.com/hku-mars/ikd-Tree.git
 	branch = fast_lio


### PR DESCRIPTION
This will allow to install fast lio even without git credentials on the local machine. This is a  problem for those who are logged in only on gitlab, bitbucket... Since the repo is public, making the URL like this it would enable anyone to install without logging in from the terminal.