### PR TITLE
Fix IMU QoS, add parameters for published topics

### DIFF
--- a/config/avia.yaml
+++ b/config/avia.yaml
@@ -12,9 +12,9 @@
         common:
             lid_topic:  "/livox/lidar"
             imu_topic:  "/livox/imu"
-            time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
+            time_sync_en: false           # ONLY turn on when external time synchronization is really not possible
             time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
-                                        # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
+                                          # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
 
         preprocess:
             lidar_type: 1                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 
@@ -39,6 +39,12 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: true       # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
+            odom_topic: "/Odometry"
+            path_topic: "/path"
+            cloud_reg_topic: "/cloud_registered"
+            cloud_reg_body_topic: "/cloud_registered_body"
+            cloud_eff_topic: "/cloud_effected"
+            laser_map_topic: "/Laser_map"
 
         pcd_save:
             pcd_save_en: true

--- a/config/avia.yaml
+++ b/config/avia.yaml
@@ -45,6 +45,8 @@
             cloud_reg_body_topic: "/cloud_registered_body"
             cloud_eff_topic: "/cloud_effected"
             laser_map_topic: "/Laser_map"
+            fixed_frame: "camera_init"
+            child_frame: "body"
 
         pcd_save:
             pcd_save_en: true

--- a/config/horizon.yaml
+++ b/config/horizon.yaml
@@ -45,6 +45,8 @@
             cloud_reg_body_topic: "/cloud_registered_body"
             cloud_eff_topic: "/cloud_effected"
             laser_map_topic: "/Laser_map"
+            fixed_frame: "camera_init"
+            child_frame: "body"
 
         pcd_save:
             pcd_save_en: true

--- a/config/horizon.yaml
+++ b/config/horizon.yaml
@@ -12,10 +12,10 @@
         common:
             lid_topic:  "/livox/lidar"
             imu_topic:  "/livox/imu"
-            time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
+            time_sync_en: false           # ONLY turn on when external time synchronization is really not possible
             time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
-                                        # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
-            
+                                          # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
+
         preprocess:
             lidar_type: 1                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 
             scan_line:  6
@@ -39,6 +39,12 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: true       # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
+            odom_topic: "/Odometry"
+            path_topic: "/path"
+            cloud_reg_topic: "/cloud_registered"
+            cloud_reg_body_topic: "/cloud_registered_body"
+            cloud_eff_topic: "/cloud_effected"
+            laser_map_topic: "/Laser_map"
 
         pcd_save:
             pcd_save_en: true

--- a/config/mid360.yaml
+++ b/config/mid360.yaml
@@ -49,6 +49,8 @@
             cloud_reg_body_topic: "/cloud_registered_body"
             cloud_eff_topic: "/cloud_effected"
             laser_map_topic: "/Laser_map"
+            fixed_frame: "camera_init"
+            child_frame: "body"
 
         pcd_save:
             pcd_save_en: true

--- a/config/mid360.yaml
+++ b/config/mid360.yaml
@@ -12,9 +12,9 @@
         common:
             lid_topic:  "/livox/lidar"
             imu_topic:  "/livox/imu"
-            time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
+            time_sync_en: false           # ONLY turn on when external time synchronization is really not possible
             time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
-                                        # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
+                                          # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
 
         preprocess:
             lidar_type: 1                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 4 for any other pointcloud input
@@ -43,6 +43,12 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: false      # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
+            odom_topic: "/Odometry"
+            path_topic: "/path"
+            cloud_reg_topic: "/cloud_registered"
+            cloud_reg_body_topic: "/cloud_registered_body"
+            cloud_eff_topic: "/cloud_effected"
+            laser_map_topic: "/Laser_map"
 
         pcd_save:
             pcd_save_en: true

--- a/config/ouster64.yaml
+++ b/config/ouster64.yaml
@@ -46,6 +46,8 @@
             cloud_reg_body_topic: "/cloud_registered_body"
             cloud_eff_topic: "/cloud_effected"
             laser_map_topic: "/Laser_map"
+            fixed_frame: "camera_init"
+            child_frame: "body"
 
         pcd_save:
             pcd_save_en: true

--- a/config/ouster64.yaml
+++ b/config/ouster64.yaml
@@ -10,12 +10,12 @@
         map_file_path: "./test.pcd"
 
         common:
-            lid_topic:  "/os_cloud_node/points"
-            imu_topic:  "/os_cloud_node/imu"
-            time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
+            lid_topic:  "/ouster/points"
+            imu_topic:  "/ouster/imu"
+            time_sync_en: false           # ONLY turn on when external time synchronization is really not possible
             time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
-                                        # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
-            
+                                          # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
+
         preprocess:
             lidar_type: 3                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 
             scan_line: 64
@@ -40,6 +40,12 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: true       # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
+            odom_topic: "/Odometry"
+            path_topic: "/path"
+            cloud_reg_topic: "/cloud_registered"
+            cloud_reg_body_topic: "/cloud_registered_body"
+            cloud_eff_topic: "/cloud_effected"
+            laser_map_topic: "/Laser_map"
 
         pcd_save:
             pcd_save_en: true

--- a/config/velodyne.yaml
+++ b/config/velodyne.yaml
@@ -12,9 +12,9 @@
         common:
             lid_topic:  "/velodyne_points"
             imu_topic:  "/imu/data"
-            time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
+            time_sync_en: false           # ONLY turn on when external time synchronization is really not possible
             time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
-                                        # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
+                                          # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
 
         preprocess:
             lidar_type: 2                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 
@@ -32,8 +32,8 @@
             det_range:     100.0
             extrinsic_est_en:  false      # true: enable the online estimation of IMU-LiDAR extrinsic,
             extrinsic_T: [ 0., 0., 0.28]
-            extrinsic_R: [ 1., 0., 0., 
-                        0., 1., 0., 
+            extrinsic_R: [ 1., 0., 0.,
+                        0., 1., 0.,
                         0., 0., 1.]
 
         publish:
@@ -41,6 +41,12 @@
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: true       # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame
+            odom_topic: "/Odometry"
+            path_topic: "/path"
+            cloud_reg_topic: "/cloud_registered"
+            cloud_reg_body_topic: "/cloud_registered_body"
+            cloud_eff_topic: "/cloud_effected"
+            laser_map_topic: "/Laser_map"
 
         pcd_save:
             pcd_save_en: true

--- a/config/velodyne.yaml
+++ b/config/velodyne.yaml
@@ -47,6 +47,8 @@
             cloud_reg_body_topic: "/cloud_registered_body"
             cloud_eff_topic: "/cloud_effected"
             laser_map_topic: "/Laser_map"
+            fixed_frame: "camera_init"
+            child_frame: "body"
 
         pcd_save:
             pcd_save_en: true

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -845,7 +845,7 @@ public:
         this->get_parameter_or<bool>("publish.dense_publish_en", dense_pub_en, true);
         this->get_parameter_or<bool>("publish.scan_bodyframe_pub_en", scan_body_pub_en, true);
         this->get_parameter_or<string>("publish.odom_topic", odom_topic, "/Odometry");
-        this->get_parameter_or<string>("publish.path_topic", odom_topic, "/path");
+        this->get_parameter_or<string>("publish.path_topic", path_topic, "/path");
         this->get_parameter_or<string>("publish.cloud_reg_topic", cloud_reg_topic, "/cloud_registered");
         this->get_parameter_or<string>("publish.cloud_reg_body_topic", cloud_reg_body_topic, "/cloud_registered_body");
         this->get_parameter_or<string>("publish.cloud_eff_topic", cloud_eff_topic, "/cloud_effected");


### PR DESCRIPTION
The lidar topic was already set to use the sensor data QoS profile and I applied the same profile to the IMU topic. This is necessary for the ouster driver but won't hurt the other sensor types. I added parameters for the published topics like odom and path so they can be set in the config file. Also updated the ouster config because the new ouster driver uses `/ouster/points` instead of `/os_cloud_node/points`

Many of the edits are just formatting fixes like removing extra whitespace.