### PR TITLE
fix: set tf timestamp

### DIFF
--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -647,6 +647,7 @@ void publish_odometry(const rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPt
     geometry_msgs::msg::TransformStamped trans;
     trans.header.frame_id = "camera_init";
     trans.child_frame_id = "body";
+    trans.header.stamp = get_ros_time(lidar_end_time);
     trans.transform.translation.x = odomAftMapped.pose.pose.position.x;
     trans.transform.translation.y = odomAftMapped.pose.pose.position.y;
     trans.transform.translation.z = odomAftMapped.pose.pose.position.z;


### PR DESCRIPTION
Add one line code `trans.header.stamp = get_ros_time(lidar_end_time);` to fix ISSUE #326 