### PR TITLE
fix: ouster_ros ring data type changed to uint16_t to match ros2 driver

### DIFF
--- a/src/preprocess.h
+++ b/src/preprocess.h
@@ -91,7 +91,7 @@ struct EIGEN_ALIGN16 Point
   float intensity;
   uint32_t t;
   uint16_t reflectivity;
-  uint8_t ring;
+  uint16_t ring;
   uint16_t ambient;
   uint32_t range;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -107,7 +107,7 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point,
     // use std::uint32_t to avoid conflicting with pcl::uint32_t
     (std::uint32_t, t, t)
     (std::uint16_t, reflectivity, reflectivity)
-    (std::uint8_t, ring, ring)
+    (std::uint16_t, ring, ring)
     (std::uint16_t, ambient, ambient)
     (std::uint32_t, range, range)
 )


### PR DESCRIPTION
For ros2, the ring information has been changed to [uint16_t](https://github.com/ouster-lidar/ouster-ros/blob/af70a816f9289ee10386350ce540568a5b1f00f5/include/ouster_ros/os_point.h#L27) 