### PR TITLE
Update laserMapping.cpp

### DIFF
--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -411,8 +411,13 @@ bool sync_packages(MeasureGroup &meas)
     meas.imu.clear();
     while ((!imu_buffer.empty()) && (imu_time < lidar_end_time))
     {
-        meas.imu.push_back(imu_buffer.front());
         imu_buffer.pop_front();
+        imu_time = imu_buffer.front()->header.stamp.toSec();
+        if (imu_time > lidar_end_time)
+           {
+             meas.imu.push_back(imu_buffer.front());
+             break;
+           }
     }
 
     lidar_buffer.pop_front();

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -411,8 +411,6 @@ bool sync_packages(MeasureGroup &meas)
     meas.imu.clear();
     while ((!imu_buffer.empty()) && (imu_time < lidar_end_time))
     {
-        imu_time = imu_buffer.front()->header.stamp.toSec();
-        if(imu_time > lidar_end_time) break;
         meas.imu.push_back(imu_buffer.front());
         imu_buffer.pop_front();
     }


### PR DESCRIPTION
mars实验室同行们，你们好：
鉴于double imu_time = imu_buffer.front()->header.stamp.toSec();已经在进入while循环前已经读取过一次了，所以再进入while循环时候先进行pop是合理的，这样让代码运行的效率也会相对高一些