### PR TITLE
Fix: ros2 ouster config and point type

### DIFF
--- a/config/ouster64.yaml
+++ b/config/ouster64.yaml
@@ -10,8 +10,8 @@
         map_file_path: "./test.pcd"
 
         common:
-            lid_topic:  "/os_cloud_node/points"
-            imu_topic:  "/os_cloud_node/imu"
+            lid_topic:  "/ouster/points"
+            imu_topic:  "/ouster/imu"
             time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
             time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
                                         # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
@@ -20,7 +20,7 @@
             lidar_type: 3                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR, 
             scan_line: 64
             timestamp_unit: 3                 # 0-second, 1-milisecond, 2-microsecond, 3-nanosecond.
-            blind: 4.0
+            blind: 2.0
 
         mapping:
             acc_cov: 0.1
@@ -30,13 +30,13 @@
             fov_degree:    360.0
             det_range:     150.0
             extrinsic_est_en:  false      # true: enable the online estimation of IMU-LiDAR extrinsic
-            extrinsic_T: [ 0.0, 0.0, 0.0 ]
-            extrinsic_R: [1., 0., 0.,
-                        0., 1., 0.,
-                        0., 0., 1.]
+            extrinsic_T: [0.002, 0.010, 0.031]
+            extrinsic_R: [-1.0,  0.0,  0.0,
+                            0.0, -1.0,  0.0,
+                            0.0,  0.0,  1.0]
 
         publish:
-            path_en:  false
+            path_en: false
             scan_publish_en:  true       # false: close all the point cloud output
             dense_publish_en: true       # false: low down the points number in a global-frame point clouds scan.
             scan_bodyframe_pub_en: true  # true: output the point cloud scans in IMU-body-frame

--- a/src/preprocess.h
+++ b/src/preprocess.h
@@ -91,7 +91,7 @@ struct EIGEN_ALIGN16 Point
   float intensity;
   uint32_t t;
   uint16_t reflectivity;
-  uint8_t ring;
+  uint16_t ring;
   uint16_t ambient;
   uint32_t range;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -107,7 +107,7 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point,
     // use std::uint32_t to avoid conflicting with pcl::uint32_t
     (std::uint32_t, t, t)
     (std::uint16_t, reflectivity, reflectivity)
-    (std::uint8_t, ring, ring)
+    (std::uint16_t, ring, ring)
     (std::uint16_t, ambient, ambient)
     (std::uint32_t, range, range)
 )


### PR DESCRIPTION
* fixes ouster ros2 point definition to avoid deprecation and ring information errors
* fixes config to reflect the changes to tf in the ouster ros2 driver, where 
  * `os_imu` now points in the perpendicular direction of `os_lidar`. IMU->Lidar transformation information was retreived with: `ros2 run tf2_ros tf2_echo os_imu os_lidar` with the driver running
  * default topics were renamed