### PR TITLE
Update preprocess.h

### DIFF
--- a/src/preprocess.h
+++ b/src/preprocess.h
@@ -62,7 +62,7 @@ namespace ouster_ros {
       float intensity;
       uint32_t t;
       uint16_t reflectivity;
-      uint8_t  ring;
+      uint16_t  ring;
       uint16_t ambient;
       uint32_t range;
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -78,7 +78,7 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point,
     // use std::uint32_t to avoid conflicting with pcl::uint32_t
     (std::uint32_t, t, t)
     (std::uint16_t, reflectivity, reflectivity)
-    (std::uint8_t, ring, ring)
+    (std::uint16_t, ring, ring)
     (std::uint16_t, ambient, ambient)
     (std::uint32_t, range, range)
 )


### PR DESCRIPTION
Update the data type for 'ring' from uint8_t to uint16_t to match Ouster's default definition